### PR TITLE
cleanup a bit

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "requiresafe/es5"
+  "extends": "nodesecurity/es5"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,69 +1,10 @@
 {
   "name": "grunt-nsp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "dependencies": {
-    "chalk": {
-      "version": "1.1.1",
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.1.0"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.3"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.0.0"
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.0.0"
-            }
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        }
-      }
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3"
-        }
-      }
-    },
     "nsp": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "requiresafe-npm-utils": {
-          "version": "2.5.3"
-        },
-        "https-proxy-agent": {
-          "version": "1.0.0"
-        },
-        "joi": {
-          "version": "6.9.1"
-        },
-        "rc": {
-          "version": "1.1.2"
-        },
-        "semver": {
-          "version": "5.0.3"
-        },
-        "subcommand": {
-          "version": "2.0.3"
-        },
-        "wreck": {
-          "version": "6.3.0"
-        },
         "agent-base": {
           "version": "2.0.1"
         },
@@ -76,6 +17,14 @@
         "ansi-styles": {
           "version": "2.1.0"
         },
+        "are-we-there-yet": {
+          "version": "1.0.4",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13"
+            }
+          }
+        },
         "asn1": {
           "version": "0.1.11"
         },
@@ -83,19 +32,19 @@
           "version": "0.1.5"
         },
         "async": {
-          "version": "1.4.2"
+          "version": "1.5.0"
         },
         "aws-sign2": {
           "version": "0.6.0"
         },
         "balanced-match": {
-          "version": "0.2.0"
+          "version": "0.2.1"
         },
         "bl": {
           "version": "1.0.0"
         },
         "boom": {
-          "version": "2.9.0"
+          "version": "2.10.1"
         },
         "brace-expansion": {
           "version": "1.1.1"
@@ -106,8 +55,14 @@
         "caseless": {
           "version": "0.11.0"
         },
+        "chalk": {
+          "version": "1.1.1"
+        },
         "chownr": {
           "version": "0.0.2"
+        },
+        "cli-table": {
+          "version": "0.3.1"
         },
         "cliclopts": {
           "version": "1.1.1"
@@ -142,20 +97,20 @@
         "deep-extend": {
           "version": "0.2.11"
         },
+        "delayed-stream": {
+          "version": "1.0.0"
+        },
         "delegates": {
           "version": "0.1.0"
         },
-        "delayed-stream": {
-          "version": "1.0.0"
+        "escape-string-regexp": {
+          "version": "1.0.3"
         },
         "extend": {
           "version": "3.0.0"
         },
         "forever-agent": {
           "version": "0.6.1"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.3"
         },
         "form-data": {
           "version": "1.0.0-rc3"
@@ -169,11 +124,11 @@
         "generate-object-property": {
           "version": "1.2.0"
         },
-        "graceful-fs": {
-          "version": "3.0.8"
-        },
         "glob": {
           "version": "5.0.15"
+        },
+        "graceful-fs": {
+          "version": "3.0.8"
         },
         "graceful-readlink": {
           "version": "1.0.1"
@@ -181,11 +136,11 @@
         "har-validator": {
           "version": "2.0.2"
         },
-        "has-unicode": {
-          "version": "1.0.1"
-        },
         "has-ansi": {
           "version": "2.0.0"
+        },
+        "has-unicode": {
+          "version": "1.0.1"
         },
         "hawk": {
           "version": "3.1.0"
@@ -198,6 +153,9 @@
         },
         "http-signature": {
           "version": "0.11.0"
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0"
         },
         "inflight": {
           "version": "1.0.4"
@@ -226,14 +184,14 @@
         "isstream": {
           "version": "0.1.2"
         },
+        "joi": {
+          "version": "6.10.0"
+        },
         "json-stringify-safe": {
           "version": "5.0.1"
         },
         "jsonpointer": {
           "version": "2.0.0"
-        },
-        "lodash": {
-          "version": "3.10.1"
         },
         "lodash._basetostring": {
           "version": "3.0.1"
@@ -263,7 +221,10 @@
           "version": "3.0.0"
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "0.0.8"
+        },
+        "mkdirp": {
+          "version": "0.5.1"
         },
         "moment": {
           "version": "2.10.6"
@@ -271,14 +232,25 @@
         "ms": {
           "version": "0.7.1"
         },
-        "normalize-package-data": {
-          "version": "2.3.4"
-        },
         "node-uuid": {
           "version": "1.4.3"
         },
+        "nodesecurity-npm-utils": {
+          "version": "3.0.0"
+        },
+        "normalize-package-data": {
+          "version": "2.3.5"
+        },
         "npm-package-arg": {
           "version": "4.0.2"
+        },
+        "npm-registry-client": {
+          "version": "6.3.3",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6"
+            }
+          }
         },
         "npmlog": {
           "version": "1.2.1"
@@ -304,8 +276,16 @@
         "qs": {
           "version": "5.2.0"
         },
+        "rc": {
+          "version": "1.1.2",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0"
+            }
+          }
+        },
         "readable-stream": {
-          "version": "2.0.2"
+          "version": "2.0.4"
         },
         "request": {
           "version": "2.65.0"
@@ -315,6 +295,9 @@
         },
         "rimraf": {
           "version": "2.4.3"
+        },
+        "semver": {
+          "version": "5.0.3"
         },
         "silent-npm-registry-client": {
           "version": "1.0.0"
@@ -326,7 +309,7 @@
           "version": "1.0.9"
         },
         "spdx-correct": {
-          "version": "1.0.1"
+          "version": "1.0.2"
         },
         "spdx-exceptions": {
           "version": "1.0.3"
@@ -335,19 +318,27 @@
           "version": "1.0.0"
         },
         "spdx-license-ids": {
-          "version": "1.0.2"
+          "version": "1.1.0"
         },
         "string_decoder": {
           "version": "0.10.31"
         },
         "stringstream": {
-          "version": "0.0.4"
+          "version": "0.0.5"
         },
         "strip-ansi": {
           "version": "3.0.0"
         },
         "strip-json-comments": {
           "version": "0.1.3"
+        },
+        "subcommand": {
+          "version": "2.0.3",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0"
+            }
+          }
         },
         "supports-color": {
           "version": "2.0.0"
@@ -373,32 +364,11 @@
         "wrappy": {
           "version": "1.0.1"
         },
+        "wreck": {
+          "version": "6.3.0"
+        },
         "xtend": {
-          "version": "4.0.0"
-        },
-        "are-we-there-yet": {
-          "version": "1.0.4",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "npm-registry-client": {
-          "version": "6.3.3",
-          "dependencies": {
-            "semver": {
-              "version": "4.3.6"
-            }
-          }
+          "version": "4.0.1"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   },
   "devDependencies": {
     "eslint": "^1.7.3",
-    "eslint-config-requiresafe": "^1.0.0",
+    "eslint-config-nodesecurity": "^1.0.0",
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "shrinkydink": "^1.0.0"
   },
   "homepage": "https://github.com/nodesecurity/grunt-nsp#readme",
@@ -23,7 +24,7 @@
     "grunt",
     "gruntplugin",
     "nodesecurity",
-    "requiresafe",
+    "nsp",
     "security"
   ],
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "url": "https://github.com/nodesecurity/grunt-nsp/issues"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
-    "cli-table": "^0.3.1",
-    "nsp": "^2.0.0"
+    "nsp": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^1.7.3",

--- a/tasks/nsp.js
+++ b/tasks/nsp.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Chalk = require('chalk');
-var Table = require('cli-table');
 var Nsp = require('nsp');
 
 module.exports = function (grunt) {


### PR DESCRIPTION
we still need to publish a new `nsp` with the correct npm-utils dep, and then regenerate the shrinkwrap here
