### PR TITLE
Added 2 new configuration options 'failOnVulns' and 'outputFile'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ This package supports the following options.
 - package (object): The contents of a single package.json file [required]
 - shrinkwrap (object): The contents of a single npm-shrinkwrap.json file (optional, but is a much more efficient check)
 - output (string): Adjust the output format to any formatter supported by [nsp](https://github.com/nodesecurity/nsp)
-- failOnVulns (boolean): When `true` fails the Grunt build, when `false` allows the build to proceed. Default is `true`. 
+- failOnVulns (boolean): When `true` fails the Grunt build, when `false` allows the build to proceed. Default is `true`.
+- outputFile (string): The filename of a file to write the formatted results to. (optional, results are always written to console)
 
 ## Command Line Options
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This package supports the following options.
 - package (object): The contents of a single package.json file [required]
 - shrinkwrap (object): The contents of a single npm-shrinkwrap.json file (optional, but is a much more efficient check)
 - output (string): Adjust the output format to any formatter supported by [nsp](https://github.com/nodesecurity/nsp)
+- failOnVulns (boolean): When `true` fails the Grunt build, when `false` allows the build to proceed. Default is `true`. 
 
 ## Command Line Options
 

--- a/tasks/nsp.js
+++ b/tasks/nsp.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Nsp = require('nsp');
-var fs = require('fs');
+var Fs = require('fs');
 
 module.exports = function (grunt) {
 
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
 
     var payload = {};
     var formatter = Nsp.formatters.default;
-    var failOnVulns = config.failOnVulns === undefined ? true: config.failOnVulns; 
+    var failOnVulns = config.failOnVulns === undefined ? true : config.failOnVulns;
 
     if (config.package) {
       payload.package = config.package;
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
       var output = formatter(err, data);
 
       if (config.outputFile) {
-        fs.writeFileSync(config.outputFile, output);
+        Fs.writeFileSync(config.outputFile, output);
       }
 
       if (err || (data.length > 0 && failOnVulns)) {

--- a/tasks/nsp.js
+++ b/tasks/nsp.js
@@ -11,6 +11,7 @@ module.exports = function (grunt) {
 
     var payload = {};
     var formatter = Nsp.formatters.default;
+    var failOnVulns = config.failOnVulns === undefined ? true: config.failOnVulns; 
 
     if (config.package) {
       payload.package = config.package;
@@ -53,7 +54,7 @@ module.exports = function (grunt) {
     Nsp.check(payload, function (err, data) {
 
       var output = formatter(err, data);
-      if (err || data.length > 0) {
+      if (err || (data.length > 0 && failOnVulns)) {
         grunt.fail.warn(output);
         return done();
       }

--- a/tasks/nsp.js
+++ b/tasks/nsp.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Nsp = require('nsp');
+var fs = require('fs');
 
 module.exports = function (grunt) {
 
@@ -54,6 +55,11 @@ module.exports = function (grunt) {
     Nsp.check(payload, function (err, data) {
 
       var output = formatter(err, data);
+
+      if (config.outputFile) {
+        fs.writeFileSync(config.outputFile, output);
+      }
+
       if (err || (data.length > 0 && failOnVulns)) {
         grunt.fail.warn(output);
         return done();


### PR DESCRIPTION
We want to use the grunt-nsp task as part of a larger build process and would like it to output in a way that can be picked up by other tools (i.e. a file) and not fail the build so other tasks can run.

This pull request adds these two simple options which are both optional so existing users will be unaffected by the change.
